### PR TITLE
Add logger and gate debug logs

### DIFF
--- a/src/features/activities/pages/ActivitiesPage.tsx
+++ b/src/features/activities/pages/ActivitiesPage.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useRef, useEffect, useCallback } from 'react';
+import { log } from '@/shared/utils/logger';
 import { motion, AnimatePresence } from 'framer-motion';
 import { createPortal } from 'react-dom';
 import { 
@@ -202,7 +203,7 @@ const Activities: React.FC = () => {
         left: rect.left,
         width: rect.width
       };
-      console.log('Dropdown position:', newPosition, 'Input rect:', rect);
+      log('Dropdown position:', newPosition, 'Input rect:', rect);
       setDropdownPosition(newPosition);
     }
   }, []);

--- a/src/features/dashboard/hooks/useDashboardMetrics.ts
+++ b/src/features/dashboard/hooks/useDashboardMetrics.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect, useMemo } from 'react';
+import { log } from '@/shared/utils/logger';
 import { DashboardService } from '@/features/dashboard/services';
 import { DashboardMetrics } from '@/shared/types/common.types';
 
@@ -94,11 +95,11 @@ export const useDashboardMetrics = () => {
     const fetchMetrics = async () => {
       try {
         setLoading(true);
-        console.log('Fetching dashboard metrics...');
+        log('Fetching dashboard metrics...');
         const response = await DashboardService.getDashboardMetrics();
         
         if (response.success && response.data) {
-          console.log('Dashboard metrics received:', response.data);
+          log('Dashboard metrics received:', response.data);
           setMetrics(response.data);
         } else {
           console.error('Error fetching dashboard metrics:', response.error);

--- a/src/features/dashboard/hooks/useDashboardReactive.ts
+++ b/src/features/dashboard/hooks/useDashboardReactive.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef } from 'react';
+import { log } from '@/shared/utils/logger';
 import { Subscription } from 'rxjs';
 import { dashboardReactiveService, DashboardState, DashboardConfig } from '@/features/dashboard/services/dashboardReactiveService';
 
@@ -99,14 +100,14 @@ export const useDashboardReactive = (config?: Partial<DashboardConfig>): UseDash
   
   // Suscripciones a streams reactivos
   useEffect(() => {
-    console.log('useDashboardReactive: Configurando suscripciones...');
+    log('useDashboardReactive: Configurando suscripciones...');
     
     const subscriptions: Subscription[] = [];
     
     // Suscripción al estado principal
     const stateSubscription = dashboardReactiveService.state$.subscribe({
       next: (newState) => {
-        console.log('useDashboardReactive: Estado actualizado:', newState);
+        log('useDashboardReactive: Estado actualizado:', newState);
         setState(newState);
       },
       error: (error) => {
@@ -118,7 +119,7 @@ export const useDashboardReactive = (config?: Partial<DashboardConfig>): UseDash
     // Suscripción a métricas procesadas
     const metricCardsSubscription = dashboardReactiveService.metricCards$.subscribe({
       next: (cards) => {
-        console.log('useDashboardReactive: Métricas actualizadas:', cards.length);
+        log('useDashboardReactive: Métricas actualizadas:', cards.length);
         setMetricCards(cards);
       },
       error: (error) => {
@@ -130,7 +131,7 @@ export const useDashboardReactive = (config?: Partial<DashboardConfig>): UseDash
     // Suscripción a gráficos procesados
     const chartCardsSubscription = dashboardReactiveService.chartCards$.subscribe({
       next: (cards) => {
-        console.log('useDashboardReactive: Gráficos actualizados:', cards.length);
+        log('useDashboardReactive: Gráficos actualizados:', cards.length);
         setChartCards(cards);
       },
       error: (error) => {
@@ -142,7 +143,7 @@ export const useDashboardReactive = (config?: Partial<DashboardConfig>): UseDash
     // Suscripción a datos de gráficos
     const chartDataSubscription = dashboardReactiveService.chartData$.subscribe({
       next: (data) => {
-        console.log('useDashboardReactive: Datos de gráficos actualizados');
+        log('useDashboardReactive: Datos de gráficos actualizados');
         setChartData(data);
       },
       error: (error) => {
@@ -156,7 +157,7 @@ export const useDashboardReactive = (config?: Partial<DashboardConfig>): UseDash
     
     // Cleanup al desmontar
     return () => {
-      console.log('useDashboardReactive: Limpiando suscripciones...');
+      log('useDashboardReactive: Limpiando suscripciones...');
       subscriptions.forEach(sub => {
         if (!sub.closed) {
           sub.unsubscribe();
@@ -168,32 +169,32 @@ export const useDashboardReactive = (config?: Partial<DashboardConfig>): UseDash
   
   // Métodos de control
   const refresh = () => {
-    console.log('useDashboardReactive: Refrescando...');
+    log('useDashboardReactive: Refrescando...');
     dashboardReactiveService.refresh();
   };
   
   const forceRefresh = () => {
-    console.log('useDashboardReactive: Forzando refresco...');
+    log('useDashboardReactive: Forzando refresco...');
     dashboardReactiveService.forceRefresh();
   };
   
   const clearError = () => {
-    console.log('useDashboardReactive: Limpiando error...');
+    log('useDashboardReactive: Limpiando error...');
     dashboardReactiveService.clearError();
   };
   
   const startPolling = () => {
-    console.log('useDashboardReactive: Iniciando polling...');
+    log('useDashboardReactive: Iniciando polling...');
     dashboardReactiveService.startPolling();
   };
   
   const stopPolling = () => {
-    console.log('useDashboardReactive: Deteniendo polling...');
+    log('useDashboardReactive: Deteniendo polling...');
     dashboardReactiveService.stopPolling();
   };
   
   const updateConfig = (newConfig: Partial<DashboardConfig>) => {
-    console.log('useDashboardReactive: Actualizando configuración...', newConfig);
+    log('useDashboardReactive: Actualizando configuración...', newConfig);
     dashboardReactiveService.updateConfig(newConfig);
   };
   

--- a/src/features/dashboard/hooks/useRecentActivitiesDashboard.ts
+++ b/src/features/dashboard/hooks/useRecentActivitiesDashboard.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
+import { log } from '@/shared/utils/logger';
 import { Subscription } from 'rxjs';
 import { RecentActivity, activityStreamService } from '@/shared/hooks/useRecentActivities';
 
@@ -204,7 +205,7 @@ export const useRecentActivitiesDashboard = (): UseRecentActivitiesDashboardRetu
    * Útil para actualizaciones manuales o después de acciones del usuario
    */
   const refreshActivities = useCallback(() => {
-    console.log('Refrescando actividades recientes...');
+    log('Refrescando actividades recientes...');
     setLoading(true);
     setError(null);
     
@@ -220,12 +221,12 @@ export const useRecentActivitiesDashboard = (): UseRecentActivitiesDashboardRetu
 
   // Efecto principal para suscribirse al stream de actividades
   useEffect(() => {
-    console.log('useRecentActivitiesDashboard: Iniciando suscripción...');
+    log('useRecentActivitiesDashboard: Iniciando suscripción...');
     
     // Suscribirse solo a las últimas 3 actividades para el dashboard
     subscriptionRef.current = activityStreamService.recentActivities$.subscribe({
       next: (recentActivities) => {
-        console.log('useRecentActivitiesDashboard: Recibidas actividades:', recentActivities.length);
+        log('useRecentActivitiesDashboard: Recibidas actividades:', recentActivities.length);
         setActivities(recentActivities);
         setLoading(false);
         setError(null);
@@ -239,7 +240,7 @@ export const useRecentActivitiesDashboard = (): UseRecentActivitiesDashboardRetu
 
     // Cleanup al desmontar el componente
     return () => {
-      console.log('useRecentActivitiesDashboard: Limpiando suscripción...');
+      log('useRecentActivitiesDashboard: Limpiando suscripción...');
       if (subscriptionRef.current) {
         subscriptionRef.current.unsubscribe();
         subscriptionRef.current = null;

--- a/src/features/dashboard/pages/Dashboard.tsx
+++ b/src/features/dashboard/pages/Dashboard.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect } from 'react';
+import { log } from '@/shared/utils/logger';
 import { motion } from 'framer-motion';
 import { useNavigate } from 'react-router-dom';
 import { 
@@ -25,9 +26,9 @@ export const Dashboard: React.FC = () => {
   useEffect(() => {
     if (metrics) {
       // Inicializar actividades recientes basadas en los datos
-      console.log('Dashboard: Inicializando actividades...');
-      console.log('Dashboard: Incidencias disponibles:', metrics.incidents?.length || 0);
-      console.log('Dashboard: Requerimientos disponibles:', metrics.requirements?.length || 0);
+      log('Dashboard: Inicializando actividades...');
+      log('Dashboard: Incidencias disponibles:', metrics.incidents?.length || 0);
+      log('Dashboard: Requerimientos disponibles:', metrics.requirements?.length || 0);
       
       generateInitialActivities(
         metrics.incidents || [],

--- a/src/features/dashboard/services/dashboardReactiveService.ts
+++ b/src/features/dashboard/services/dashboardReactiveService.ts
@@ -17,6 +17,7 @@ import {
   timeout
 } from 'rxjs/operators';
 import { DashboardService } from './dashboardService';
+import { log } from '@/shared/utils/logger';
 import { DashboardMetrics } from '@/shared/types/common.types';
 
 /**
@@ -557,7 +558,7 @@ export class DashboardReactiveService {
    * Destruye el servicio y limpia recursos
    */
   public destroy(): void {
-    console.log('DashboardReactiveService: Destruyendo servicio...');
+    log('DashboardReactiveService: Destruyendo servicio...');
     this.destroySubject.next();
     this.destroySubject.complete();
     this.stateSubject.complete();

--- a/src/features/dashboard/services/dashboardService.ts
+++ b/src/features/dashboard/services/dashboardService.ts
@@ -17,6 +17,7 @@
 
 import { dashboardApi } from '@/shared/services';
 import { DashboardMetrics } from '@/shared/types/common.types';
+import { log } from '@/shared/utils/logger';
 
 /**
  * Interfaz para las respuestas del servicio del dashboard
@@ -41,9 +42,9 @@ export class DashboardService {
    */
   static async getDashboardMetrics(): Promise<DashboardServiceResponse> {
     try {
-      console.log('DashboardService: Obteniendo métricas del dashboard...');
+      log('DashboardService: Obteniendo métricas del dashboard...');
       const data = await dashboardApi.getDashboardMetrics();
-      console.log('DashboardService: Métricas obtenidas exitosamente:', data);
+      log('DashboardService: Métricas obtenidas exitosamente:', data);
       
       return {
         success: true,
@@ -66,9 +67,9 @@ export class DashboardService {
    */
   static async refreshDashboardMetrics(): Promise<DashboardServiceResponse> {
     try {
-      console.log('DashboardService: Refrescando métricas del dashboard...');
+      log('DashboardService: Refrescando métricas del dashboard...');
       const data = await dashboardApi.getDashboardMetrics();
-      console.log('DashboardService: Métricas refrescadas exitosamente:', data);
+      log('DashboardService: Métricas refrescadas exitosamente:', data);
       
       return {
         success: true,
@@ -96,14 +97,14 @@ export class DashboardService {
     status?: string;
   }): Promise<DashboardServiceResponse> {
     try {
-      console.log('DashboardService: Obteniendo métricas con filtro:', filter);
+      log('DashboardService: Obteniendo métricas con filtro:', filter);
       
       // Aquí se implementaría la lógica de filtrado
       // Por ahora usamos la API base
       const data = await dashboardApi.getDashboardMetrics();
       
       // TODO: Implementar filtrado real cuando la API lo soporte
-      console.log('DashboardService: Métricas filtradas obtenidas:', data);
+      log('DashboardService: Métricas filtradas obtenidas:', data);
       
       return {
         success: true,
@@ -127,7 +128,7 @@ export class DashboardService {
    */
   static async getRealTimeStats(): Promise<DashboardServiceResponse> {
     try {
-      console.log('DashboardService: Obteniendo estadísticas en tiempo real...');
+      log('DashboardService: Obteniendo estadísticas en tiempo real...');
       
       // TODO: Implementar endpoint de tiempo real cuando esté disponible
       const data = await dashboardApi.getDashboardMetrics();
@@ -154,7 +155,7 @@ export class DashboardService {
    */
   static async exportDashboardData(format: 'csv' | 'excel' | 'pdf'): Promise<DashboardServiceResponse> {
     try {
-      console.log(`DashboardService: Exportando datos en formato ${format}...`);
+      log(`DashboardService: Exportando datos en formato ${format}...`);
       
       // TODO: Implementar exportación cuando esté disponible
       const data = await dashboardApi.getDashboardMetrics();
@@ -181,7 +182,7 @@ export class DashboardService {
    */
   static async validateDataFreshness(): Promise<{ isFresh: boolean; lastUpdated?: string }> {
     try {
-      console.log('DashboardService: Validando frescura de datos...');
+      log('DashboardService: Validando frescura de datos...');
       
       // TODO: Implementar validación de frescura cuando esté disponible
       return {

--- a/src/features/incidents/hooks/pages/useIncidentsPage.ts
+++ b/src/features/incidents/hooks/pages/useIncidentsPage.ts
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { log } from '@/shared/utils/logger';
 import { useIncidents, useModal, useIncidentFilters, useFilterOptions } from '@/features/incidents/hooks';
 import { useAuth } from '@/features/auth/hooks/useAuth';
 import { Incident, IncidentStatus } from '@/shared/types/common.types';
@@ -44,22 +45,22 @@ export const useIncidentsPage = () => {
 
   // Manejadores de acciones de incidencias
   const handleIncidentClick = (incident: Incident) => {
-    console.log('Incident clicked:', incident);
+    log('Incident clicked:', incident);
     // Aquí puedes implementar la lógica de clic en incidencia
   };
 
   const handleEditIncident = (incident: Incident) => {
-    console.log('Edit incident:', incident);
+    log('Edit incident:', incident);
     // Aquí puedes implementar la lógica de edición
   };
 
   const handleDeleteIncident = (incident: Incident) => {
-    console.log('Delete incident:', incident);
+    log('Delete incident:', incident);
     // Aquí puedes implementar la lógica de eliminación
   };
 
   const handleViewIncident = (incident: Incident) => {
-    console.log('View incident:', incident);
+    log('View incident:', incident);
     // Aquí puedes implementar la lógica de visualización
   };
 

--- a/src/features/requirements/hooks/pages/useRequirementsPage.ts
+++ b/src/features/requirements/hooks/pages/useRequirementsPage.ts
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { log } from '@/shared/utils/logger';
 import { useRequirements, useRequirementModal } from '@/features/requirements/hooks';
 import { Requirement, RequirementType, RequirementStatus, Priority } from '@/shared/types/common.types';
 
@@ -95,22 +96,22 @@ export const useRequirementsPage = () => {
 
   // Manejadores de acciones de requerimientos
   const handleRequirementClick = (requirement: Requirement) => {
-    console.log('Requirement clicked:', requirement);
+    log('Requirement clicked:', requirement);
     // Aquí puedes implementar la lógica de clic en requerimiento
   };
 
   const handleEditRequirement = (requirement: Requirement) => {
-    console.log('Edit requirement:', requirement);
+    log('Edit requirement:', requirement);
     // Aquí puedes implementar la lógica de edición
   };
 
   const handleDeleteRequirement = (requirement: Requirement) => {
-    console.log('Delete requirement:', requirement);
+    log('Delete requirement:', requirement);
     // Aquí puedes implementar la lógica de eliminación
   };
 
   const handleViewRequirement = (requirement: Requirement) => {
-    console.log('View requirement:', requirement);
+    log('View requirement:', requirement);
     // Aquí puedes implementar la lógica de visualización
   };
 

--- a/src/shared/hooks/useCleanup.ts
+++ b/src/shared/hooks/useCleanup.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from 'react';
 import { cleanupActivities } from './useRecentActivities';
+import { log } from '@/shared/utils/logger';
 
 export const useCleanup = () => {
   const intervalRef = useRef<NodeJS.Timeout | null>(null);
@@ -9,7 +10,7 @@ export const useCleanup = () => {
     const cleanupInterval = 24 * 60 * 60 * 1000; // 24 horas en milisegundos
     
     const performCleanup = () => {
-      console.log('Ejecutando limpieza automática de actividades...');
+      log('Ejecutando limpieza automática de actividades...');
       cleanupActivities();
     };
 

--- a/src/shared/hooks/useRecentActivities.ts
+++ b/src/shared/hooks/useRecentActivities.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef } from 'react';
+import { log } from '@/shared/utils/logger';
 import { BehaviorSubject, Subscription } from 'rxjs';
 import { map, distinctUntilChanged, debounceTime } from 'rxjs/operators';
 import { Incident, Requirement } from '@/shared/types/common.types';
@@ -40,11 +41,11 @@ class ActivityStreamService {
     // Verificar si ya existe una actividad con el mismo ID
     const existingActivity = this.activities.find(a => a.id === activity.id);
     if (existingActivity) {
-      console.log('Actividad duplicada detectada, saltando:', activity.id);
+      log('Actividad duplicada detectada, saltando:', activity.id);
       return;
     }
     
-    console.log('Agregando actividad:', activity);
+    log('Agregando actividad:', activity);
     this.activities.unshift(activity);
     
     // Mantener solo las últimas maxActivities para evitar memory leaks
@@ -52,7 +53,7 @@ class ActivityStreamService {
       this.activities = this.activities.slice(0, this.maxActivities);
     }
     
-    console.log('Total actividades en stream:', this.activities.length);
+    log('Total actividades en stream:', this.activities.length);
     // Emitir nueva lista
     this.activitiesSubject.next([...this.activities]);
   }
@@ -185,11 +186,11 @@ export const useAllActivities = () => {
   const subscriptionRef = useRef<Subscription | null>(null);
 
   useEffect(() => {
-    console.log('useAllActivities: Suscribiéndose al stream...');
+    log('useAllActivities: Suscribiéndose al stream...');
     // Suscribirse a todas las actividades
     subscriptionRef.current = activityStreamService.allActivities$.subscribe({
       next: (allActivities) => {
-        console.log('useAllActivities: Recibidas actividades:', allActivities.length);
+        log('useAllActivities: Recibidas actividades:', allActivities.length);
         setActivities(allActivities);
         setLoading(false);
       },
@@ -221,13 +222,13 @@ export const generateInitialActivities = (
 ) => {
   // Evitar generar actividades duplicadas
   if (hasInitialized) {
-    console.log('Actividades ya inicializadas, saltando...');
+    log('Actividades ya inicializadas, saltando...');
     return [];
   }
   
-  console.log('Generando actividades iniciales...');
-  console.log('Incidencias recibidas:', incidents.length);
-  console.log('Requerimientos recibidos:', requirements.length);
+  log('Generando actividades iniciales...');
+  log('Incidencias recibidas:', incidents.length);
+  log('Requerimientos recibidos:', requirements.length);
   
   const activities: RecentActivity[] = [];
 
@@ -290,15 +291,15 @@ export const generateInitialActivities = (
     .sort((a, b) => b.timestamp.getTime() - a.timestamp.getTime())
     .slice(0, 20); // Solo las 20 más recientes para inicialización
 
-  console.log('Actividades generadas:', sortedActivities.length);
-  console.log('Actividades:', sortedActivities);
+  log('Actividades generadas:', sortedActivities.length);
+  log('Actividades:', sortedActivities);
 
   // Agregar al stream de manera optimizada
   sortedActivities.forEach(activity => {
     activityStreamService.addActivity(activity);
   });
 
-  console.log('Actividades agregadas al stream');
+  log('Actividades agregadas al stream');
   hasInitialized = true; // Marcar como inicializado
   return sortedActivities;
 };

--- a/src/shared/utils/logger.ts
+++ b/src/shared/utils/logger.ts
@@ -1,0 +1,18 @@
+export const log = (...args: unknown[]) => {
+  if (import.meta.env && import.meta.env.DEV) {
+    // eslint-disable-next-line no-console
+    console.log(...args);
+  }
+};
+export const warn = (...args: unknown[]) => {
+  if (import.meta.env && import.meta.env.DEV) {
+    // eslint-disable-next-line no-console
+    console.warn(...args);
+  }
+};
+export const error = (...args: unknown[]) => {
+  if (import.meta.env && import.meta.env.DEV) {
+    // eslint-disable-next-line no-console
+    console.error(...args);
+  }
+};


### PR DESCRIPTION
## Summary
- create a simple logger that only logs in development mode
- replace scattered `console.log` calls with the new logger

## Testing
- `npm run type-check` *(fails: TS errors)*
- `npm run build` *(fails: TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_688b073545d083209ae7a722fd151fc2