### PR TITLE
Use logger for dashboard metrics debug

### DIFF
--- a/src/shared/services/api/dashboard/dashboardApi.ts
+++ b/src/shared/services/api/dashboard/dashboardApi.ts
@@ -2,6 +2,7 @@
 import { DashboardMetrics } from '@/shared/types/common.types';
 import { incidentsApi } from '../incidents/incidentsApi';
 import { requirementsApi } from '../requirements/requirementsApi';
+import { log } from '@/shared/utils/logger';
 
 // Simulación de datos de dashboard
 let dashboardData: DashboardMetrics | null = null;
@@ -57,7 +58,7 @@ const generateDashboardMetrics = async (): Promise<DashboardMetrics> => {
   }
   
   // Debug: Mostrar información del cálculo
-  console.log('🔍 Dashboard Metrics Debug (Mock Data):', {
+  log('🔍 Dashboard Metrics Debug (Mock Data):', {
     totalIncidents,
     highPriority: highPriorityIncidents,
     mediumPriority: mediumPriorityIncidents,


### PR DESCRIPTION
## Summary
- import `log` from shared logger in dashboard API
- use logger instead of `console.log` for dashboard metrics debug

## Testing
- `npm run type-check` *(fails: cannot find various TypeScript declarations)*

------
https://chatgpt.com/codex/tasks/task_e_688b29ddcdd4832090ee3c67b299ddff