### PR TITLE
Fix react-window peer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
         "react-icons": "^5.5.0",
         "react-loading-skeleton": "^3.5.0",
         "react-router-dom": "^6.28.0",
-        "react-window": "^1.8.9",
+        "react-window": "^1.8.11",
         "recharts": "^2.12.7",
         "rxjs": "^7.8.2",
         "tailwind-merge": "^2.6.0",
@@ -6614,9 +6614,9 @@
       }
     },
     "node_modules/react-window": {
-      "version": "1.8.9",
-      "resolved": "https://registry.npmjs.org/react-window/-/react-window-1.8.9.tgz",
-      "integrity": "sha512-+Eqx/fj1Aa5WnhRfj9dJg4VYATGwIUP2ItwItiJ6zboKWA6EX3lYDAXfGF2hyNqplEprhbtjbipiADEcwQ823Q==",
+      "version": "1.8.11",
+      "resolved": "https://registry.npmjs.org/react-window/-/react-window-1.8.11.tgz",
+      "integrity": "sha512-+SRbUVT2scadgFSWx+R1P754xHPEqvcfSfVX10QYg6POOz+WNgkN48pS+BtZNIMGiL1HYrSEiCkwsMS15QogEQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.0.0",
@@ -6626,8 +6626,8 @@
         "node": ">8.0.0"
       },
       "peerDependencies": {
-        "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0",
-        "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
+        "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/read-cache": {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "react-icons": "^5.5.0",
     "react-loading-skeleton": "^3.5.0",
     "react-router-dom": "^6.28.0",
-    "react-window": "^1.8.9",
+    "react-window": "^1.8.11",
     "recharts": "^2.12.7",
     "rxjs": "^7.8.2",
     "tailwind-merge": "^2.6.0",


### PR DESCRIPTION
## Summary
- update `react-window` to version `^1.8.11` to support React 19

## Testing
- `npm install --no-progress`
- `npm run lint` *(fails: ESLint couldn't find a config file)*
- `npm run type-check` *(fails: TypeScript compilation errors)*

------
https://chatgpt.com/codex/tasks/task_e_688b3042c61c8320b8d5c01d12c9af1b